### PR TITLE
fix argparse bug

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import moodle_downloader
 
 # Instantiate the argument parser
 arg_parser = argparse.ArgumentParser()
+arg_parser.set_defaults(func=lambda _: arg_parser.print_help())
 
 
 def setup_parser():


### PR DESCRIPTION
When running `python3 src/main.py` without any additional arguments, the program fails without printing an usage message after entering the credentials (see below).

Output on the console:
```
$ python3 src/main.py
Enter password for [user]:
Starting Moodle session...
Traceback (most recent call last):
  File "/home/noah/.programs/tum-moodle-downloader-fork/src/main.py", line 76, in <module>
    args.func(args)
    ^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'func'
```
This is a [known bug](https://github.com/python/cpython/issues/60512) from argparse version 3.3.0 and above and can be fixed as seen [here](https://stackoverflow.com/questions/48648036/python-argparse-args-has-no-attribute-func). 
With this fix the program simply terminates by displaying an usage message.

Output on the console after fix:
```
$ python3 src/main.py
Enter password for [user]:
Starting Moodle session
usage: main.py [-h] {list,download} ...

positional arguments:
  {list,download}
    list           List available resources of the specified "course" or, if no
                   course is specified, list available courses
    download       Download resources which match a "file_pattern" from a "course"
                   into a "destination" path. If parameters are omitted they are
                   retrieved from "src/course_config.json"

options:
  -h, --help       show this help message and exit
```